### PR TITLE
[Setting] SwiftLint 설정 및 기본 룰셋 적용 (#3)

### DIFF
--- a/chukapoka/.swiftlint.yml
+++ b/chukapoka/.swiftlint.yml
@@ -1,0 +1,28 @@
+# MARK: - 기본 설정
+disabled_rules: # 초보자에게 너무 엄격한 건 끄자 !
+  - trailing_whitespace             # 줄 끝 공백은 나중에 제거하자
+  - identifier_name                 # 변수명 너무 엄격하면 초보에겐 부담
+  - function_body_length            # 뷰에서 로직 뺄 땐 길어질 수 있음
+  - nesting                         # SwiftUI 구조상 중첩 뷰 많음
+  - line_length                     # View 선언이 길어질 수 있음
+  - cyclomatic_complexity           # 조건문 많아지는 건 초기엔 자연스러움
+
+opt_in_rules: # SwiftUI와 MVVM 스타일에서 명시적으로 켜줄 것들
+  - attributes                      # @MainActor, @State 등 속성 정렬
+  - closure_end_indentation         # 클로저 끝 들여쓰기 일관되게
+  - empty_count                     # .count == 0보다 .isEmpty 쓰기
+  - redundant_optional_initialization # ?= nil 금지
+  - explicit_type_interface         # ViewModel 변수 타입 명시하자
+
+type_name: # ViewModel, View 등 이름 길이 제한 완화
+  min_length: 3
+  max_length: 40
+
+function_parameter_count:
+  warning: 6
+  error: 8
+
+# MARK: - 제외할 파일들
+excluded:
+  - chukapokaApp.swift              # 앱 진입점
+  - AppDelegate.swift               # 폰트 등록/앱 초기화 로직 등

--- a/chukapoka/chukapoka.xcodeproj/project.pbxproj
+++ b/chukapoka/chukapoka.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		D59F7C7C2DEB00E000A829A8 /* InfoStep1View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoStep1View.swift; sourceTree = "<group>"; };
 		D59F7C7E2DEB019100A829A8 /* GroupCreateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupCreateViewModel.swift; sourceTree = "<group>"; };
 		D59F7C802DEB09BF00A829A8 /* EnterCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterCodeView.swift; sourceTree = "<group>"; };
+		D59F7C9E2DECC2B100A829A8 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,6 +85,7 @@
 		D59F7C192DEAEB3600A829A8 = {
 			isa = PBXGroup;
 			children = (
+				D59F7C9E2DECC2B100A829A8 /* .swiftlint.yml */,
 				D59F7C542DEAF20600A829A8 /* chukapoka */,
 				D59F7C232DEAEB3600A829A8 /* Products */,
 			);
@@ -200,6 +202,7 @@
 				D59F7C1E2DEAEB3600A829A8 /* Sources */,
 				D59F7C1F2DEAEB3600A829A8 /* Frameworks */,
 				D59F7C202DEAEB3600A829A8 /* Resources */,
+				D59F7C972DECBBE000A829A8 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -321,6 +324,27 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		D59F7C972DECBBE000A829A8 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		D59F7C1E2DEAEB3600A829A8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -407,7 +431,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -470,7 +494,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/chukapoka/chukapoka/App/AppDelegate.swift
+++ b/chukapoka/chukapoka/App/AppDelegate.swift
@@ -4,4 +4,3 @@
 //
 //  Created by Demian Yoo on 5/31/25.
 //
-

--- a/chukapoka/chukapoka/App/RootNaivationView.swift
+++ b/chukapoka/chukapoka/App/RootNaivationView.swift
@@ -9,24 +9,23 @@ import SwiftUI
 
 struct RootNavigationView: View {
     @EnvironmentObject var coordinator: AppCoordinator
-    @StateObject private var groupCreateViewModel = GroupCreateViewModel()
+    @StateObject private var groupCreateViewModel: GroupCreateViewModel = GroupCreateViewModel()
     
     var body: some View {
         NavigationStack(path: $coordinator.path) {
             HomeView()
                 .navigationDestination(for: AppRoute.self) { route in
-                    switch route{
+                    switch route {
                     case .home:
                         HomeView()
                     
-                    //그룹 생성 파티장 flow
+                    // 그룹 생성 파티장 flow
                     case .groupCreate(.infoStep1):
                         InfoStep1View(viewModel: groupCreateViewModel)
                     
-                    //그룹 참여 파티원 flow
+                    // 그룹 참여 파티원 flow
                     case . groupJoin(.enterCode):
                         EnterCodeView()
-                        
                         
                     }
                 }

--- a/chukapoka/chukapoka/App/chukapokaApp.swift
+++ b/chukapoka/chukapoka/App/chukapokaApp.swift
@@ -9,13 +9,13 @@ import SwiftUI
 import SwiftData
 
 @main
-struct chukapokaApp: App {
-    @StateObject private var coordinator = AppCoordinator()
+struct ChukapokaApp: App {
+    @StateObject private var coordinator: AppCoordinator = AppCoordinator()
     
     var body: some Scene {
         WindowGroup {
             RootNavigationView()
-                //전역 주입
+                // 전역 주입
                 .environmentObject(coordinator)
         }
     }

--- a/chukapoka/chukapoka/Coordinator/AppCoordinator.swift
+++ b/chukapoka/chukapoka/Coordinator/AppCoordinator.swift
@@ -10,9 +10,8 @@ import SwiftUI
 @MainActor
 final class AppCoordinator: ObservableObject {
     
-    //Navigation Stack과 바인딩할 Path
+    // Navigation Stack과 바인딩할 Path
     @Published var path: [AppRoute] = []
-    
     
     func push(_ route: AppRoute) {
         path.append(route)

--- a/chukapoka/chukapoka/Coordinator/AppRoute.swift
+++ b/chukapoka/chukapoka/Coordinator/AppRoute.swift
@@ -4,8 +4,6 @@
 //
 //  Created by Demian Yoo on 5/31/25.
 //
-
-
 import Foundation
 
 enum AppRoute: Hashable {

--- a/chukapoka/chukapoka/Core/Constants.swift
+++ b/chukapoka/chukapoka/Core/Constants.swift
@@ -4,4 +4,3 @@
 //
 //  Created by Demian Yoo on 5/31/25.
 //
-

--- a/chukapoka/chukapoka/Core/DesignSystem.swift
+++ b/chukapoka/chukapoka/Core/DesignSystem.swift
@@ -4,4 +4,3 @@
 //
 //  Created by Demian Yoo on 5/31/25.
 //
-

--- a/chukapoka/chukapoka/Feature/GroupCreate/GroupCreateViewModel.swift
+++ b/chukapoka/chukapoka/Feature/GroupCreate/GroupCreateViewModel.swift
@@ -4,8 +4,6 @@
 //
 //  Created by Demian Yoo on 5/31/25.
 //
-
-
 import Foundation
 import SwiftUI
 


### PR DESCRIPTION
## ✨ 작업한 내용

- 관련이슈: #3 ( Closes: #3 )
- `.swiftlint.yml` 생성 및 설정
- Build Phase에 SwiftLint Run Script 추가
- 실리콘 Mac 대응 (PATH 추가)
- 앱 진입점 파일들(like `AppDelegate`, `chukapokaApp.swift`)은 린트 제외 처리

## 📸 미리 보기 (UI 작업일 경우 첨부)

> 스크린샷, GIF 등

## ✅ Xcode Run Script 예시

> Build Phases → + Run Script 추가 후 아래 코드 입력:

```bash
if [[ "$(uname -m)" == "arm64" ]]; then
    export PATH="/opt/homebrew/bin:$PATH"
fi

if which swiftlint > /dev/null; then
    swiftlint
else
    echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
fi
```

## 💬 룰셋 참고할 부분

attributes
애트리뷰트는 한 줄에 하나씩, 그리고 선언 위에 위치시켜야 합니다.
```swift
@StateObject
private var viewModel = MyViewModel()
```

closure_end_indentation
클로저를 닫는 }는 들여쓰기가 함수 호출 기준에 맞춰 정렬되어야 합니다.
```swift
someFunction {
    print("hi")
} // ← 이 } 들여쓰기 맞춰야 경고 없음
```

empty_count
배열이나 문자열이 비었는지 체크할 땐 .isEmpty를 사용하세요.
```swift
array.count == 0
array.isEmpty
```

redundant_optional_initialization
옵셔널 변수는 기본값 없이 선언하면 nil로 자동 초기화됩니다.
var name: String? = nil
var name: String?

explicit_type_interface
@StateObject, @Published 등의 프로퍼티는 타입을 명시하세요.
@StateObject var vm = MyViewModel()
@StateObject var vm: MyViewModel = MyViewModel()

type_name
타입명은 최소 3자 이상, 최대 40자까지로 설정되어 있습니다.
예시: GroupCreateViewModel, AppCoordinator
VM, V

function_parameter_count
함수 파라미터는 6개 이상일 경우 리팩터링을 고려해주세요.
예시: 별도의 struct로 묶거나, DTO, Request 모델로 전달

excluded
앱 진입점(AppDelegate, chukapokaApp.swift)은 예외 처리되어 린트 경고를 무시합니다.
이 파일들은 시스템 필수 구조로 SwiftLint 룰에서 제외하는 것이 일반적입니다.

