### PR TITLE
[Feat] CustomTextField 컴포넌트 구현

### DIFF
--- a/chukapoka/chukapoka/Core/DesignSystem/Components/CustomTextField.swift
+++ b/chukapoka/chukapoka/Core/DesignSystem/Components/CustomTextField.swift
@@ -1,0 +1,109 @@
+//
+//  CustomTextField.swift
+//  chukapoka
+//
+//  Created by 조유진 on 6/2/25.
+//
+import SwiftUI
+
+struct CustomTextField: View {
+    let title: String
+    let infoText: String?
+    let placeholder: String
+    @Binding var text: String
+    let action: (() -> Void)?
+    @Binding var isValid: Bool
+    
+    init(
+        title: String,
+        infoText: String? = nil,
+        placeholder: String,
+        text: Binding<String>,
+        action: (() -> Void)? = nil,
+        isValid: Binding<Bool>,
+    ) {
+        self.title = title
+        self.infoText = infoText
+        self.placeholder = placeholder
+        self._text = text
+        self.action = action
+        self._isValid = isValid
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 0) {
+                Text(title)
+                    .font(GSFont.body2)
+                    .foregroundColor(GSColor.black)
+                if let info = infoText {
+                    Text(info)
+                        .font(GSFont.body2)
+                        .foregroundColor(GSColor.gray1)
+                }
+            }
+            
+            ZStack(alignment: .leading) {
+                if text.isEmpty {
+                    Text(placeholder)
+                        .foregroundColor(GSColor.gray3)
+                        .padding(.horizontal, 15)
+                        .padding(.vertical, 12)
+                }
+                
+                TextField("", text: $text, onEditingChanged: { isEditing in
+                    if isEditing {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            isValid = true
+                        }
+                    }
+                    action?()
+                })
+                .accentColor(GSColor.primary)
+                .padding()
+                
+            }
+            .onChange(of: text) {
+                if !isValid {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        isValid = true
+                    }
+                }
+            }
+            .background(GSColor.secondary3)
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isValid ? Color.clear : Color.red, lineWidth: 1)
+            )
+        }
+        .frame(maxWidth: .infinity, minHeight: 52, alignment: .topLeading)
+    }
+}
+
+#Preview {
+    // 한글 입력만 받을 수 있도록 예외처리 하는 예시 프리뷰입니다.
+    struct PreviewWrapper: View {
+        @State private var inputText: String = ""
+        @State private var isValid: Bool = true  // 상태를 외부에서 관리
+        
+        var body: some View {
+            VStack(spacing: 16) {
+                CustomTextField(
+                    title: "받을 분",
+                    infoText: "(신랑 혹은 신부)", // 없으면 작성하지 않아도 되는 부분
+                    placeholder: "어떤 파티에서 화환을 전달하나요?",
+                    text: $inputText,
+                    isValid: $isValid
+                )
+                
+                Button("확인") {
+                    // 버튼 누를 때 검사
+                    isValid = inputText.range(of: #"[\u{AC00}-\u{D7AF}]"#, options: .regularExpression) != nil
+                }
+            }
+            .padding()
+        }
+    }
+    return PreviewWrapper()
+}


### PR DESCRIPTION
## ✨ 작업한 내용

- 관련 이슈: Closes #16 
- CustomTextField 컴포넌트를 구현하였습니다.
- 컴포넌트 외부 유효성 검사에 따라 오류 피드백 제공할 수 있도록 구현하였습니다.
- 오류 피드백 이후, 사용자가 다시 TextField에 포커스 하면 피드백이 제거됩니다.
- 내부 Preview에 사용 예시 제작했습니다. 컴포넌트 사용시 참고해주시면 될 것 같습니다!

## 📸 미리 보기 (UI 작업일 경우 첨부)
<img width="389" alt="스크린샷 2025-06-03 00 52 56" src="https://github.com/user-attachments/assets/b5cef64f-21e0-44e3-b76f-b96039e81186" />

## ✅ 체크리스트

예시)
- [x] 관련 이슈를 닫는 커밋 메시지 사용 (`Closes #`)
- [x] 동작 확인 완료 (시뮬레이터 / 실기기)
- [x] 커밋 메시지 규칙 준수
- [ ] 불필요한 주석/코드 제거
- [x] 리뷰어가 이해하기 쉬운 설명 작성

## 💬 논의하고 싶은 부분
올바른 입력을 받으면 초록색으로 피드백을 표시해야할까요?