### PR TITLE
[Feat] 메인화면 UI View 구현 완료

### DIFF
--- a/chukapoka/chukapoka.xcodeproj/project.pbxproj
+++ b/chukapoka/chukapoka.xcodeproj/project.pbxproj
@@ -109,6 +109,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D51C80C12DEF47740051CB40 /* SubViews */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SubViews;
+			sourceTree = "<group>";
+		};
 		D574E9AD2DED7F6A00AAF70F /* DesignSystem */ = {
 			isa = PBXGroup;
 			children = (
@@ -228,6 +235,7 @@
 		D59F7C602DEAF4E000A829A8 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				D51C80C12DEF47740051CB40 /* SubViews */,
 				D59F7C772DEB005E00A829A8 /* HomeView.swift */,
 			);
 			path = Home;

--- a/chukapoka/chukapoka.xcodeproj/project.pbxproj
+++ b/chukapoka/chukapoka.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D51C80C32DEF48210051CB40 /* HomeIntroText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51C80C22DEF481C0051CB40 /* HomeIntroText.swift */; };
+		D51C80C52DEF482A0051CB40 /* HomeChracterImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51C80C42DEF48260051CB40 /* HomeChracterImage.swift */; };
+		D51C80CB2DEF487F0051CB40 /* HomeBottomButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51C80CA2DEF487C0051CB40 /* HomeBottomButtons.swift */; };
 		D56CD4042DEF3BFD002267B1 /* GSImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56CD4032DEF3BED002267B1 /* GSImage.swift */; };
 		D574E9B12DED7FA000AAF70F /* PrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D574E9B02DED7F9400AAF70F /* PrimaryButton.swift */; };
 		D574E9D02DED897A00AAF70F /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = D574E9C62DED897A00AAF70F /* Pretendard-Black.otf */; };
@@ -52,6 +55,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D51C80C22DEF481C0051CB40 /* HomeIntroText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeIntroText.swift; sourceTree = "<group>"; };
+		D51C80C42DEF48260051CB40 /* HomeChracterImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeChracterImage.swift; sourceTree = "<group>"; };
+		D51C80CA2DEF487C0051CB40 /* HomeBottomButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBottomButtons.swift; sourceTree = "<group>"; };
 		D56CD4032DEF3BED002267B1 /* GSImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSImage.swift; sourceTree = "<group>"; };
 		D574E9B02DED7F9400AAF70F /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
 		D574E9C52DED890000AAF70F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -112,6 +118,9 @@
 		D51C80C12DEF47740051CB40 /* SubViews */ = {
 			isa = PBXGroup;
 			children = (
+				D51C80C22DEF481C0051CB40 /* HomeIntroText.swift */,
+				D51C80C42DEF48260051CB40 /* HomeChracterImage.swift */,
+				D51C80CA2DEF487C0051CB40 /* HomeBottomButtons.swift */,
 			);
 			path = SubViews;
 			sourceTree = "<group>";
@@ -235,8 +244,8 @@
 		D59F7C602DEAF4E000A829A8 /* Home */ = {
 			isa = PBXGroup;
 			children = (
-				D51C80C12DEF47740051CB40 /* SubViews */,
 				D59F7C772DEB005E00A829A8 /* HomeView.swift */,
+				D51C80C12DEF47740051CB40 /* SubViews */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -440,11 +449,14 @@
 				D574E9DA2DED8A6500AAF70F /* GSFont.swift in Sources */,
 				D59F7C7D2DEB00ED00A829A8 /* InfoStep1View.swift in Sources */,
 				D574E9B12DED7FA000AAF70F /* PrimaryButton.swift in Sources */,
+				D51C80C32DEF48210051CB40 /* HomeIntroText.swift in Sources */,
 				D59F7C782DEB006200A829A8 /* HomeView.swift in Sources */,
 				D56CD4042DEF3BFD002267B1 /* GSImage.swift in Sources */,
+				D51C80C52DEF482A0051CB40 /* HomeChracterImage.swift in Sources */,
 				D59F7C762DEAF6E100A829A8 /* AppRoute.swift in Sources */,
 				D59F7C702DEAF69400A829A8 /* Constants.swift in Sources */,
 				D5ED63172DED427B007912E1 /* RootNavigationView.swift in Sources */,
+				D51C80CB2DEF487F0051CB40 /* HomeBottomButtons.swift in Sources */,
 				D59F7C812DEB09C200A829A8 /* EnterCodeView.swift in Sources */,
 				D574E9DE2DEDEE3500AAF70F /* PairButton.swift in Sources */,
 			);

--- a/chukapoka/chukapoka/Feature/Home/HomeView.swift
+++ b/chukapoka/chukapoka/Feature/Home/HomeView.swift
@@ -11,16 +11,66 @@ struct HomeView: View {
     @EnvironmentObject var coordinator: AppCoordinator
 
     var body: some View {
-        VStack(spacing: 10) {
-            Button("🎉 그룹 만들기") {
-                coordinator.push(.groupCreate(.infoStep1))
-            }
-
-            Button("💌 코드 입력하기") {
-                coordinator.push(.groupJoin(.enterCode))
-            }
+        mainContent()
+    }
+    
+    // MARK: - Main View
+    @ViewBuilder
+    private func mainContent() -> some View {
+        VStack(spacing: 0) {
+            Spacer()
+            introSection()
+            Spacer()
+            actionSection()
+                .padding(.bottom, 58)
         }
-        .navigationTitle("홈")
+    }
+    
+    // MARK: - 상단 소개 문구 + 이미지
+    @ViewBuilder
+    private func introSection() -> some View {
+        VStack(spacing: 96) {
+            introText
+            pokiImage
+        }
+    }
+    
+    private var introText: some View {
+        Text("멤버를 초대하고\n함께 축하해보세요")
+            .multilineTextAlignment(.center)
+            .font(GSFont.title2)
+            .foregroundColor(GSColor.black)
+    }
+    
+    private var pokiImage: some View {
+        GSImage.mainLogo
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 214, height: 214)
+    }
+    
+    // MARK: - 하단 버튼 섹션
+    @ViewBuilder
+    private func actionSection() -> some View {
+        PairButton(
+            leftTitle: "그룹 생성하기",
+            rightTitle: "코드로 참여하기",
+            leftStyle: .custom(
+                textColor: GSColor.primary,
+                backgroundColor: GSColor.secondary3,
+                isEnable: true),
+            rightStyle: .custom(
+                textColor: GSColor.white,
+                backgroundColor: GSColor.primary,
+                isEnable: true),
+            leftAction: {
+                coordinator.push(.groupCreate(.infoStep1))
+            },
+            rightAction: {
+                    coordinator.push(.groupJoin(.enterCode))
+            }
+        )
+        .padding(.horizontal, 16)
     }
 }
 

--- a/chukapoka/chukapoka/Feature/Home/HomeView.swift
+++ b/chukapoka/chukapoka/Feature/Home/HomeView.swift
@@ -11,69 +11,26 @@ struct HomeView: View {
     @EnvironmentObject var coordinator: AppCoordinator
 
     var body: some View {
-        mainContent()
-    }
-    
-    // MARK: - Main View
-    @ViewBuilder
-    private func mainContent() -> some View {
         VStack(spacing: 0) {
             Spacer()
-            introSection()
+            HomeIntroText()
+                .padding(.bottom, 96)
+            HomeChracterImage()
             Spacer()
-            actionSection()
-                .padding(.bottom, 58)
-        }
-    }
-    
-    // MARK: - 상단 소개 문구 + 이미지
-    @ViewBuilder
-    private func introSection() -> some View {
-        VStack(spacing: 96) {
-            introText
-            pokiImage
-        }
-    }
-    
-    private var introText: some View {
-        Text("멤버를 초대하고\n함께 축하해보세요")
-            .multilineTextAlignment(.center)
-            .font(GSFont.title2)
-            .foregroundColor(GSColor.black)
-    }
-    
-    private var pokiImage: some View {
-        GSImage.mainLogo
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: 214, height: 214)
-    }
-    
-    // MARK: - 하단 버튼 섹션
-    @ViewBuilder
-    private func actionSection() -> some View {
-        PairButton(
-            leftTitle: "그룹 생성하기",
-            rightTitle: "코드로 참여하기",
-            leftStyle: .custom(
-                textColor: GSColor.primary,
-                backgroundColor: GSColor.secondary3,
-                isEnable: true),
-            rightStyle: .custom(
-                textColor: GSColor.white,
-                backgroundColor: GSColor.primary,
-                isEnable: true),
-            leftAction: {
-                coordinator.push(.groupCreate(.infoStep1))
-            },
-            rightAction: {
+            HomeBottomButtons(
+                onGroupCreateTapped: {
+                    coordinator.push(.groupCreate(.infoStep1))
+                },
+                onGroupJoinTapped: {
                     coordinator.push(.groupJoin(.enterCode))
-            }
-        )
-        .padding(.horizontal, 16)
+                }
+            )
+            .padding(.bottom, 16)
+        }
     }
 }
 
 #Preview {
     HomeView()
+        .environmentObject(AppCoordinator())
 }

--- a/chukapoka/chukapoka/Feature/Home/SubViews/HomeBottomButtons.swift
+++ b/chukapoka/chukapoka/Feature/Home/SubViews/HomeBottomButtons.swift
@@ -1,0 +1,30 @@
+//
+//  HomeBottomButtons.swift
+//  chukapoka
+//
+//  Created by Demian Yoo on 6/4/25.
+//
+import SwiftUI
+
+struct HomeBottomButtons: View {
+    let onGroupCreateTapped: () -> Void
+    let onGroupJoinTapped: () -> Void
+    
+    var body: some View {
+        PairButton(
+            leftTitle: "그룹 생성하기",
+            rightTitle: "코드로 참여하기",
+            leftStyle: .custom(
+                textColor: GSColor.primary,
+                backgroundColor: GSColor.white,
+                isEnable: true),
+            rightStyle: .custom(
+                textColor: GSColor.white,
+                backgroundColor: GSColor.primary,
+                isEnable: true),
+            leftAction: onGroupCreateTapped,
+            rightAction: onGroupJoinTapped
+        )
+        .padding(.horizontal, 16)
+    }
+}

--- a/chukapoka/chukapoka/Feature/Home/SubViews/HomeChracterImage.swift
+++ b/chukapoka/chukapoka/Feature/Home/SubViews/HomeChracterImage.swift
@@ -1,0 +1,16 @@
+//
+//  HomeChracterImage.swift
+//  chukapoka
+//
+//  Created by Demian Yoo on 6/4/25.
+//
+import SwiftUI
+
+struct HomeChracterImage: View {
+    var body: some View {
+        GSImage.mainLogo
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 200, height: 200)
+    }
+}

--- a/chukapoka/chukapoka/Feature/Home/SubViews/HomeIntroText.swift
+++ b/chukapoka/chukapoka/Feature/Home/SubViews/HomeIntroText.swift
@@ -1,0 +1,16 @@
+//
+//  HomeIntroText.swift
+//  chukapoka
+//
+//  Created by Demian Yoo on 6/4/25.
+//
+import SwiftUI
+
+struct HomeIntroText: View {
+    var body: some View {
+        Text("멤버를 초대하고\n함께 축하해보세요")
+            .multilineTextAlignment(.center)
+            .font(GSFont.title2)
+            .foregroundColor(GSColor.black)
+    }
+}


### PR DESCRIPTION
## ✨ 작업한 내용

- 관련 이슈: #26  ( Closes #26 )

- HomeView 내에서 각 UI 구성요소를 @ViewBuilder 및 private var로 정의했으나,
Apple Developer Academy 스타일 가이드에서 권장하는 방식(Struct 기반 SubView 분리)에 맞지 않음을 확인

- 이에 따라 각각의 UI 요소들을 역할별로 명확히 분리된 SubView Struct로 추출하였고,
HomeIntroText, HomeCharacterImage, HomeActionSection으로 분리하여 View 책임 분리 및 재사용 가능성 확보

## 📸 미리 보기 (UI 작업일 경우 첨부)

### 초반 구현 방식

![스크린샷 2025-06-04 오전 12 40 34](https://github.com/user-attachments/assets/f66d24c7-d2bc-4e02-bef7-0b186c39517f)
![스크린샷 2025-06-04 오전 12 40 37](https://github.com/user-attachments/assets/23a9cc29-a78c-4b72-a288-49114c370f50)

### ADA 스위프트 스타일 가이드 리팩토링

![스크린샷 2025-06-04 오전 12 40 55](https://github.com/user-attachments/assets/228bd0d5-a71c-47e8-95bf-a87d8880
![스크린샷 2025-06-04 오전 12 41 06](https://github.com/user-attachments/assets/5e161641-c4c8-4bda-9bd5-6ee4d3d4ea78)
2be5)



### 최종 구현 스크린샷

![Simulator Screenshot - iPhone 16 - 2025-06-04 at 00 43 03](https://github.com/user-attachments/assets/eb44e7e1-8775-4022-8de6-ff44bd72e17b)


## ✅ 체크리스트

- [ ] 관련 이슈를 닫는 커밋 메시지 사용 (Closes #26)
- [ ] 시뮬레이터 / Preview 기반 동작 확인 완료
- [ ] 커밋 메시지 규칙 ([Refactor] View 구조 개선) 준수
- [ ] 불필요한 ViewBuilder / computed property 제거
- [ ] 리뷰어가 이해하기 쉬운 역할 기반 View 이름 구성

## 💬 논의하고 싶은 부분

- HomeActionSection 네이밍이 너무 길어질 경우, HomeBottomButtons, ActionPairView 등으로 네이밍을 변경하는 것이 더 적절한지 논의 필요
- 향후 동일한 레이아웃 구조(VStack → Spacer → Content → Spacer → ButtonSection)를 다른 화면에서도 사용할 예정인데, 이를 Layout 컴포넌트로 추출할지?
- SVG로 해당 Poki 파일 추출하여 사용하였으나 1024*1024 여서 그런지 Assets 추가시 잘리는 현상 발생 이후 PDF로 추출하였으나 사진 퀄리티 낮아짐 이슈 발생