### PR TITLE
[Feat] 화환 제작 완료 화면 및 카드를 보여주는 기능 구현

### DIFF
--- a/chukapoka/chukapoka.xcodeproj/project.pbxproj
+++ b/chukapoka/chukapoka.xcodeproj/project.pbxproj
@@ -25,6 +25,11 @@
 		CA0B87F22DF022070001F120 /* FlowerstandStep2.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0B87F12DF022070001F120 /* FlowerstandStep2.swift */; };
 		CA2C4A492DF0513700D8E170 /* FlowerstandCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2C4A482DF0512E00D8E170 /* FlowerstandCardView.swift */; };
 		CA2C4A4B2DF0525000D8E170 /* CardDecorationPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2C4A4A2DF0525000D8E170 /* CardDecorationPicker.swift */; };
+		CA7B385A2DF17F7100A8254E /* FinishFlowerstandCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7B38592DF17F7100A8254E /* FinishFlowerstandCard.swift */; };
+		CA7B385C2DF1814B00A8254E /* LeftText.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7B385B2DF1814B00A8254E /* LeftText.swift */; };
+		CA7B385E2DF182E900A8254E /* RightText.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7B385D2DF182E900A8254E /* RightText.swift */; };
+		CA7B38622DF18B4A00A8254E /* FinishFlowerstandContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7B38612DF18B4A00A8254E /* FinishFlowerstandContent.swift */; };
+		CAE035832DF1F8A300DB6526 /* FlowerstandCardData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE035822DF1F8A300DB6526 /* FlowerstandCardData.swift */; };
 		D51C80C32DEF48210051CB40 /* HomeIntroText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51C80C22DEF481C0051CB40 /* HomeIntroText.swift */; };
 		D51C80C52DEF482A0051CB40 /* HomeChracterImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51C80C42DEF48260051CB40 /* HomeChracterImage.swift */; };
 		D51C80CB2DEF487F0051CB40 /* HomeBottomButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51C80CA2DEF487C0051CB40 /* HomeBottomButtons.swift */; };
@@ -108,6 +113,11 @@
 		CA0B87F12DF022070001F120 /* FlowerstandStep2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowerstandStep2.swift; sourceTree = "<group>"; };
 		CA2C4A482DF0512E00D8E170 /* FlowerstandCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowerstandCardView.swift; sourceTree = "<group>"; };
 		CA2C4A4A2DF0525000D8E170 /* CardDecorationPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDecorationPicker.swift; sourceTree = "<group>"; };
+		CA7B38592DF17F7100A8254E /* FinishFlowerstandCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishFlowerstandCard.swift; sourceTree = "<group>"; };
+		CA7B385B2DF1814B00A8254E /* LeftText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftText.swift; sourceTree = "<group>"; };
+		CA7B385D2DF182E900A8254E /* RightText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightText.swift; sourceTree = "<group>"; };
+		CA7B38612DF18B4A00A8254E /* FinishFlowerstandContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishFlowerstandContent.swift; sourceTree = "<group>"; };
+		CAE035822DF1F8A300DB6526 /* FlowerstandCardData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowerstandCardData.swift; sourceTree = "<group>"; };
 		D51C80C22DEF481C0051CB40 /* HomeIntroText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeIntroText.swift; sourceTree = "<group>"; };
 		D51C80C42DEF48260051CB40 /* HomeChracterImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeChracterImage.swift; sourceTree = "<group>"; };
 		D51C80CA2DEF487C0051CB40 /* HomeBottomButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBottomButtons.swift; sourceTree = "<group>"; };
@@ -238,6 +248,10 @@
 			isa = PBXGroup;
 			children = (
 				CA064B322DF07AF40048F794 /* FlowerstandStep4.swift */,
+				CA7B38592DF17F7100A8254E /* FinishFlowerstandCard.swift */,
+				CA7B385B2DF1814B00A8254E /* LeftText.swift */,
+				CA7B385D2DF182E900A8254E /* RightText.swift */,
+				CA7B38612DF18B4A00A8254E /* FinishFlowerstandContent.swift */,
 			);
 			path = Step4;
 			sourceTree = "<group>";
@@ -261,10 +275,19 @@
 		CA0B87EA2DF021300001F120 /* CreateFlowerstand */ = {
 			isa = PBXGroup;
 			children = (
+				CAE035812DF1F88100DB6526 /* Model */,
 				CA064B272DF06B8C0048F794 /* SubViews */,
 				CA0B87EB2DF0217A0001F120 /* CreateFlowerstandView.swift */,
 			);
 			path = CreateFlowerstand;
+			sourceTree = "<group>";
+		};
+		CAE035812DF1F88100DB6526 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				CAE035822DF1F8A300DB6526 /* FlowerstandCardData.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		D51C80C12DEF47740051CB40 /* SubViews */ = {
@@ -692,11 +715,13 @@
 				D5951B002DEFF68C006863B6 /* CustomTextField.swift in Sources */,
 				D59F7C562DEAF20600A829A8 /* chukapokaApp.swift in Sources */,
 				CA0B87F02DF021F50001F120 /* FlowerstandStep1.swift in Sources */,
+				CAE035832DF1F8A300DB6526 /* FlowerstandCardData.swift in Sources */,
 				844720592DF1700500FE9441 /* CustomProgressView.swift in Sources */,
 				D5B38C3C2DF045FB005DAFDC /* PartyCardActionIcons.swift in Sources */,
 				D574E9DC2DED8E2E00AAF70F /* GSColor.swift in Sources */,
 				D5B38C642DF0AB04005DAFDC /* PartyCardBackContainer.swift in Sources */,
 				CA064B222DF05DE60048F794 /* FlowerstandStep3.swift in Sources */,
+				CA7B38622DF18B4A00A8254E /* FinishFlowerstandContent.swift in Sources */,
 				D574E9DA2DED8A6500AAF70F /* GSFont.swift in Sources */,
 				D51C80D52DEF6B890051CB40 /* Party.swift in Sources */,
 				D5B38C592DF09A11005DAFDC /* PartyCardBackground.swift in Sources */,
@@ -718,6 +743,7 @@
 				D5B38C442DF0475A005DAFDC /* PartyCardStyle.swift in Sources */,
 				D59F7C762DEAF6E100A829A8 /* AppRoute.swift in Sources */,
 				D5B38C3E2DF04621005DAFDC /* PartyCardTitle.swift in Sources */,
+				CA7B385C2DF1814B00A8254E /* LeftText.swift in Sources */,
 				D59F7C702DEAF69400A829A8 /* Constants.swift in Sources */,
 				CA064B262DF061AD0048F794 /* SelectedFlowerGroup.swift in Sources */,
 				D5B38C5B2DF09B3F005DAFDC /* PartyCardContainer.swift in Sources */,
@@ -725,11 +751,13 @@
 				D51C80CB2DEF487F0051CB40 /* HomeBottomButtons.swift in Sources */,
 				CA064B2E2DF074040048F794 /* CreateRibbonMessage.swift in Sources */,
 				D59F7C812DEB09C200A829A8 /* EnterCodeView.swift in Sources */,
+				CA7B385E2DF182E900A8254E /* RightText.swift in Sources */,
 				CA064B352DF07B090048F794 /* FlowerstandStep5.swift in Sources */,
 				CA2C4A492DF0513700D8E170 /* FlowerstandCardView.swift in Sources */,
 				D51C80D32DEF6B820051CB40 /* Wedding.swift in Sources */,
 				CA0B87EC2DF0217A0001F120 /* CreateFlowerstandView.swift in Sources */,
 				5551279E2DF12DD6002CC923 /* TextfieldDown.swift in Sources */,
+				CA7B385A2DF17F7100A8254E /* FinishFlowerstandCard.swift in Sources */,
 				D574E9DE2DEDEE3500AAF70F /* PairButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/chukapoka/chukapoka/Feature/CreateFlowerstand/Model/FlowerstandCardData.swift
+++ b/chukapoka/chukapoka/Feature/CreateFlowerstand/Model/FlowerstandCardData.swift
@@ -1,0 +1,18 @@
+//
+//  FlowerstandCardData.swift
+//  chukapoka
+//
+//  Created by 조유진 on 6/6/25.
+//
+
+import Foundation
+import SwiftUI
+
+struct FlowerstandCardData: Equatable, Identifiable {
+    let id: UUID = UUID()
+    var name: String
+    var selectedColor: Color
+    var selectedFlower: String
+    var partyName: String
+    var ribbonText: String
+}

--- a/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step2/FlowerstandCardView.swift
+++ b/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step2/FlowerstandCardView.swift
@@ -9,22 +9,29 @@ import SwiftUI
 struct FlowerstandCardView: View {
     var selectedColor: Color
     var selectedFlower: String
+    var width: CGFloat = 235
+    var height: CGFloat = 301
     
     var body: some View {
         VStack {
             Rectangle()
                 .foregroundColor(.clear)
-                .frame(width: 235, height: 301)
+                .frame(width: width, height: height)
                 .background(selectedColor)
                 .cornerRadius(16)
                 .overlay(
                     Image("BaseFlowerstand")
+                        .resizable()
+                        .frame(width: width-10, height: height)
                 )
                 .overlay(
-                    SelectedFlowerGroup(selectedFlower: selectedFlower)
-                        .offset(x: 15, y: 15)
+                    SelectedFlowerGroup(
+                        selectedFlower: selectedFlower,
+                        containerWidth: width * 0.3,
+                        containerHeight: height * 0.32
+                    )
+                    .offset(x: 15, y: 15)
                 )
-            
         }
     }
 }

--- a/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step2/SelectedFlowerGroup.swift
+++ b/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step2/SelectedFlowerGroup.swift
@@ -9,24 +9,36 @@ import SwiftUI
 
 struct SelectedFlowerGroup: View {
     var selectedFlower: String
-    
-    // 개별 꽃의 위치 데이터를 배열로 저장
-    let flowerOffsets: [CGSize] = [
-        CGSize(width: -6.5, height: -49),
-        CGSize(width: -34.5, height: -22),
-        CGSize(width: 5.5, height: -6),
-        CGSize(width: -28.5, height: 20)
-    ]
-    
+    var containerWidth: CGFloat
+    var containerHeight: CGFloat
+
+    // 기준 크기
+    let baseWidth: CGFloat = 69
+    let baseHeight: CGFloat = 98
+
+    // 비율 기반 offset
+    var relativeOffsets: [CGSize] {
+        [
+            CGSize(width: -6.5 / baseWidth, height: -49 / baseHeight),
+            CGSize(width: -34.5 / baseWidth, height: -22 / baseHeight),
+            CGSize(width: 5.5 / baseWidth, height: -6 / baseHeight),
+            CGSize(width: -28.5 / baseWidth, height: 20 / baseHeight)
+        ]
+    }
+
     var body: some View {
         ZStack {
-            ForEach(0..<flowerOffsets.count, id: \.self) { index in
+            ForEach(0..<relativeOffsets.count, id: \.self) { index in
+                let offset = relativeOffsets[index]
                 Image(selectedFlower)
                     .resizable()
-                    .frame(width: 26, height: 27)
-                    .offset(flowerOffsets[index])
+                    .frame(width: containerWidth * 0.35, height: containerHeight * 0.27)
+                    .offset(
+                        x: containerWidth * offset.width,
+                        y: containerHeight * offset.height
+                    )
             }
         }
-        .frame(width: 69, height: 98)
+        .frame(width: containerWidth, height: containerHeight)
     }
 }

--- a/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step4/FinishFlowerstandCard.swift
+++ b/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step4/FinishFlowerstandCard.swift
@@ -1,0 +1,31 @@
+//
+//  FinishFlowerstandCard.swift
+//  chukapoka
+//
+//  Created by 조유진 on 6/5/25.
+//
+
+import SwiftUI
+
+struct FinishFlowerstandCard: View {
+    var selectedColor: Color
+    var selectedFlower: String
+    var partyName: String
+    var ribbonText: String
+    
+    var body: some View {
+        FlowerstandCardView(
+            selectedColor: selectedColor,
+            selectedFlower: selectedFlower,
+            width: 275,
+            height: 399
+        )
+        .overlay(
+            HStack(spacing: 105) {
+                LeftText(partyName: partyName)
+                RightText(ribbonText: ribbonText)
+            }
+                .padding(.bottom, 12)
+        )
+    }
+}

--- a/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step4/FinishFlowerstandContent.swift
+++ b/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step4/FinishFlowerstandContent.swift
@@ -1,0 +1,30 @@
+//
+//  FinishFlowerstandContent.swift
+//  chukapoka
+//
+//  Created by 조유진 on 6/5/25.
+//
+
+import SwiftUI
+
+struct FinishFlowerstandContent: View {
+    var cardData: FlowerstandCardData
+
+    var body: some View {
+        Spacer()
+        
+        VStack(spacing: 59) {
+            Text("\(cardData.name)님 만의\n화환 카드가 준비되었어요!")
+                .font(GSFont.title2)
+                .foregroundColor(GSColor.black)
+                .multilineTextAlignment(.center)
+            
+            FinishFlowerstandCard(
+                selectedColor: cardData.selectedColor,
+                selectedFlower: cardData.selectedFlower,
+                partyName: cardData.partyName,
+                ribbonText: cardData.ribbonText
+            )
+        }
+    }
+}

--- a/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step4/FlowerstandStep4.swift
+++ b/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step4/FlowerstandStep4.swift
@@ -8,20 +8,23 @@
 import SwiftUI
 
 struct FlowerstandStep4: View {
-    @State var name: String = "강지수"
+    @State private var cardData: FlowerstandCardData = FlowerstandCardData(
+        name: "강지수",
+        selectedColor: GSColor.yellow,
+        selectedFlower: "YellowFlower",
+        partyName: "경조사실무팀",
+        ribbonText: "행복하세요!"
+    )
     
     var body: some View {
-        VStack(alignment: .center, spacing: 155) {
-            Text("\(name)님 만의\n화환이 준비되었어요!")
-                .font(GSFont.title2)
-                .foregroundColor(GSColor.black)
-                .multilineTextAlignment(.center)
+        VStack(alignment: .center) {
+            FinishFlowerstandContent(cardData: cardData)
+            
+            Spacer()
             
             PrimaryButton(title: "카드 보내기", style: .basic)
+                .padding(.bottom, 30)
         }
+        .padding(.horizontal, 16)
     }
-}
-
-#Preview {
-    FlowerstandStep4()
 }

--- a/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step4/LeftText.swift
+++ b/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step4/LeftText.swift
@@ -1,0 +1,23 @@
+//
+//  LeftText.swift
+//  chukapoka
+//
+//  Created by 조유진 on 6/5/25.
+//
+
+import SwiftUI
+
+struct LeftText: View {
+    var partyName: String
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(partyName), id: \.self) { char in
+                Text(String(char))
+                    .font(GSFont.body2)
+                    .foregroundColor(GSColor.white)
+            }
+        }
+        .rotationEffect(Angle(degrees: 23))
+    }
+}

--- a/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step4/RightText.swift
+++ b/chukapoka/chukapoka/Feature/CreateFlowerstand/SubViews/Step4/RightText.swift
@@ -1,0 +1,23 @@
+//
+//  RightText.swift
+//  chukapoka
+//
+//  Created by 조유진 on 6/5/25.
+//
+
+import SwiftUI
+
+struct RightText: View {
+    var ribbonText: String
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(ribbonText), id: \.self) { char in
+                Text(String(char))
+                    .font(GSFont.body2)
+                    .foregroundColor(GSColor.white)
+            }
+        }
+        .rotationEffect(Angle(degrees: -22.5))
+    }
+}


### PR DESCRIPTION
## ✨ 작업한 내용

- 관련 이슈: #28 
- 카드 프레임 크기에 맞춰 화환 이미지, 꽃 이미지 크기가 조정되도록 변경하였습니다.
- DI를 위해 카드에 필요한 데이터를 담는 모델 구조체를 생성하고 적용했습니다.
- 앞 단계에서 선택한 데이터들을 기반으로 최종 완성된 화환 카드를 화면에 표시하는 기능을 완성했습니다.

## 📸 미리 보기 (UI 작업일 경우 첨부)
![Simulator Screenshot - iPhone 16 - 2025-06-06 at 01 17 42](https://github.com/user-attachments/assets/377105c9-d1c9-456c-ba3b-d1a4bf61a0f8)

## ✅ 체크리스트
- [ ] 관련 이슈를 닫는 커밋 메시지 사용 (`Closes #`)
- [x] 동작 확인 완료 (시뮬레이터 / 실기기)
- [x] 커밋 메시지 규칙 준수
- [x] 불필요한 주석/코드 제거
- [x] 리뷰어가 이해하기 쉬운 설명 작성

## 💬 논의하고 싶은 부분
텍스트 각도는 용서해주세요.. 제 최선입니다.